### PR TITLE
Adjust WooCommerce Blocks installation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ wp package install git@github.com:nielslange/woo-test-environment.git
 ```sh
 wp woo-test-environment setup
 ```
+
 ```sh
 wp woo-test-environment teardown
 ```
@@ -27,16 +28,46 @@ wp woo-test-environment teardown
 
 The command `wp woo-test-environment setup` can accept the following optional parameter:
 
-- `--version=<version>` This parameter installs a certain WooCommerce Blocks version.
+- `--blocks=<true || version>` This parameter installs a certain WooCommerce Blocks version.
 - `--gutenberg=<true>` This parameter installs and activates the latest version of the Gutenberg plugin.
 - `--theme=<theme>` This parameter installs and activates the latest version of a certain theme.
 
-### Example
+### Examples
 
-The following example shows how to set up a testing enviuronment using the WooCommerce Blocks 7.3.0 plugin, the latest Gutenberg plugin and teh latest Storefront theme:
+Installing WooCommerce only
 
+```sh
+wp woo-test-environment setup
 ```
-wp woo-test-environment setup --version=7.3.0 --gutenberg=true --theme=storefront
+
+Installing WooCommerce and WooCommerce Blocks
+
+```sh
+wp woo-test-environment setup --blocks=true
+```
+
+Installing WooCommerce, WooCommerce Blocks and Gutenberg
+
+```sh
+wp woo-test-environment setup --blocks=true --gutenberg=true
+```
+
+Installing WooCommerce and WooCommerce Blocks 7.3.0
+
+```sh
+wp woo-test-environment setup --blocks=7.3.0
+```
+
+Installing WooCommerce and Storefront
+
+```sh
+wp woo-test-environment setup --theme=storefront
+```
+
+Installing WooCommerce, WooCommerce Blocks, Gutenberg and Storefront
+
+```sh
+wp woo-test-environment setup --blocks=true --gutenberg=true --theme=storefront
 ```
 
 ## Contributing

--- a/command.php
+++ b/command.php
@@ -21,10 +21,10 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--blocks=<true||version>]
+	 * [--blocks[=<version>]]
 	 * : The desired WooCommerce Blocks version to install. When selecting 'true', the most recent version gets installed.
 	 *
-	 * [--gutenberg=<true>]
+	 * [--gutenberg]
 	 * : Whether to install and activate the Gutenberg plugin.
 	 *
 	 * [--theme=<theme>]
@@ -84,9 +84,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	private function setupPlugins( $assoc_args ) {
 		// Install and activate the latest or a certain WooCommerce Blocks release.
 		if ( isset( $assoc_args['blocks'] ) ) {
-			if ( 'true' === $assoc_args['blocks'] ) {
-				WP_CLI::runcommand( 'plugin install woo-gutenberg-products-block --activate' );
-			} elseif ( preg_match( '/\d.\d.\d/', $assoc_args['blocks'] ) ) {
+			if ( preg_match( '/\d.\d.\d/', $assoc_args['blocks'] ) ) {
 				try {
 					$plugin = "https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases/download/v{$assoc_args['blocks']}/woo-gutenberg-products-block.zip";
 					WP_CLI::runcommand( "plugin install {$plugin} --activate" );
@@ -94,11 +92,13 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 					WP_CLI::error( "WooCommerce Blocks release {$assoc_args['block']} could not be installed!" );
 					WP_CLI::error( $th );
 				}
+			} else {
+				WP_CLI::runcommand( 'plugin install woo-gutenberg-products-block --activate' );
 			}
 		}
 
 		// Install and activate the Gutenberg plugin, if desired.
-		if ( isset( $assoc_args['gutenberg'] ) && 'true' === $assoc_args['gutenberg'] ) {
+		if ( isset( $assoc_args['gutenberg'] ) ) {
 			WP_CLI::runcommand( 'plugin install gutenberg --activate' );
 		}
 

--- a/command.php
+++ b/command.php
@@ -96,7 +96,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 		}
 
 		// Install and activate the Gutenberg plugin, if desired.
-		if ( isset( $assoc_args['gutenberg'] ) && true === $assoc_args['gutenberg'] ) {
+		if ( isset( $assoc_args['gutenberg'] ) && 'true' === $assoc_args['gutenberg'] ) {
 			WP_CLI::runcommand( 'plugin install gutenberg --activate' );
 		}
 

--- a/command.php
+++ b/command.php
@@ -19,14 +19,10 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	/**
 	 * Set up WooCommerce Blocks Testing Environment.
 	 *
-	 * @param array $args An array with optional arguments.
-	 * @param array $assoc_args An array with optional arguments.
-	 * @return string Success or error message.
-	 *
 	 * ## OPTIONS
 	 *
-	 * [--version=<version>]
-	 * : The desired WooCommerce Blocks release to install.
+	 * [--blocks=<true || version>]
+	 * : The desired WooCommerce Blocks version to install. When selecting 'true', the most recent version gets installed.
 	 *
 	 * [--gutenberg=<true>]
 	 * : Whether to install and activate the Gutenberg plugin.
@@ -37,7 +33,11 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp woo-test-environment setup --version=7.3.0
+	 *     wp woo-test-environment setup --blocks=true --gutenberg=true --theme=storefront
+	 *
+	 * @param array $args An array with optional arguments.
+	 * @param array $assoc_args An array with optional arguments.
+	 * @return void
 	 */
 	public function setup( $args, $assoc_args ) {
 		// Bail early when running command within a multisite.
@@ -80,14 +80,18 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 * @return void
 	 */
 	private function setupPlugins( $assoc_args ) {
-		// Install and activate a certain WooCommerce Blocks release, if desired.
-		if ( isset( $assoc_args['version'] ) && preg_match( '/\d.\d.\d/', $assoc_args['version'] ) ) {
-			try {
-				$plugin = "https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases/download/v{$assoc_args['version']}/woo-gutenberg-products-block.zip";
-				WP_CLI::runcommand( "plugin install {$plugin} --activate" );
-			} catch ( \Throwable $th ) {
-				WP_CLI::error( "WooCommerce Blocks release {$assoc_args['version']} could not be installed!" );
-				WP_CLI::error( $th );
+		// Install and activate the latest or a certain WooCommerce Blocks release.
+		if ( isset( $assoc_args['blocks'] ) ) {
+			if ( 'true' === $assoc_args['blocks'] ) {
+				WP_CLI::runcommand( 'plugin install woo-gutenberg-products-block --activate' );
+			} elseif ( preg_match( '/\d.\d.\d/', $assoc_args['blocks'] ) ) {
+				try {
+					$plugin = "https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases/download/v{$assoc_args['blocks']}/woo-gutenberg-products-block.zip";
+					WP_CLI::runcommand( "plugin install {$plugin} --activate" );
+				} catch ( \Throwable $th ) {
+					WP_CLI::error( "WooCommerce Blocks release {$assoc_args['block']} could not be installed!" );
+					WP_CLI::error( $th );
+				}
 			}
 		}
 
@@ -128,7 +132,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 * @return void
 	 */
 	private function setupPages() {
-		// Create Shop page with block.
+		 // Create Shop page with block.
 		WP_CLI::runcommand( 'post create --menu_order=0 --post_type=page --post_status=publish --post_title=\'Shop\' --post_content=\'<!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image",{"imageSizing":"cropped"}],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} --><div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;,{&quot;imageSizing&quot;:&quot;cropped&quot;}],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}"></div><!-- /wp:woocommerce/all-products -->\'' );
 
 		// Create (default) Shop page.
@@ -168,7 +172,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 * @return void
 	 */
 	private function setupPosts() {
-		// Create All Reviews post.
+		 // Create All Reviews post.
 		WP_CLI::runcommand( 'post create --post_status=publish --post_title=\'All Reviews\' --post_content=\'<!-- wp:woocommerce/all-reviews --><div class="wp-block-woocommerce-all-reviews wc-block-all-reviews has-image has-name has-date has-rating has-content has-product-name" data-image-type="reviewer" data-orderby="most-recent" data-reviews-on-page-load="10" data-reviews-on-load-more="10" data-show-load-more="true" data-show-orderby="true"></div><!-- /wp:woocommerce/all-reviews -->\'' );
 
 		// Create Active Product Filters post.

--- a/command.php
+++ b/command.php
@@ -346,7 +346,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 			)
 		);
 
-		return $result->return_code === 0;
+		return 0 === $result->return_code;
 	}
 }
 

--- a/command.php
+++ b/command.php
@@ -21,7 +21,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--blocks=<true || version>]
+	 * [--blocks=<true||version>]
 	 * : The desired WooCommerce Blocks version to install. When selecting 'true', the most recent version gets installed.
 	 *
 	 * [--gutenberg=<true>]


### PR DESCRIPTION
Fixes #1 

This PR changes the installation logic for the WooCommerce Blocks. Before this change, the WooCommerce Blocks plugin had to be installed using the following code:

```sh
wp woo-test-environment setup --version=7.3.0
```

This PR changed `--version` to `-blocks` leading to the following possibilities:

1. Installing the latest version of WooCommerce Blocks:
```sh
wp woo-test-environment setup --blocks=true
```
2. Installing version 7.3.0 of the WooCommerce Blocks
```sh
wp woo-test-environment setup --blocks=7.3.0
```

## Testing steps

1. Check out this repo.
2. Switch to the `update/1-adjust-blocks-installation-logic` branch.
3. Install the WP-CLI custom command using
```
wp package install <path-to-your-local-repo>
```
4. Spin up a test environment with the most recent version of WooCommerce Blocks using
```
wp woo-test-environment setup --blocks=true
```
5. Tear down the test environment using
```
wp woo-test-environment teardown
```
6. Spin up a test environment with WooCommerce Blocks 7.9.0 using
```
wp woo-test-environment setup --blocks=7.9.0
```