### PR TITLE
Allow installing the WooCommerce Blocks plugin from a url

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Installing WooCommerce and WooCommerce Blocks 7.3.0
 wp woo-test-environment setup --blocks=7.3.0
 ```
 
+Installing WooCommerce and WooCommerce Blocks via URL
+
+```sh
+wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
+```
+
 Installing WooCommerce and Storefront
 
 ```sh

--- a/command.php
+++ b/command.php
@@ -36,13 +36,26 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *    wp woo-test-environment setup --blocks
-	 *    wp woo-test-environment setup --blocks=7.9.0
-	 *    wp woo-test-environment setup --blocks=//github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
-	 *
-	 *    wp woo-test-environment setup --gutenberg
-	 *
-	 *    wp woo-test-environment setup --theme=storefront
+* 		# Installing WooCommerce only
+   *    $ wp woo-test-environment setup
+   *
+   *    # Installing WooCommerce and WooCommerce Blocks
+   *    $ wp woo-test-environment setup --blocks
+   *
+   *    # Installing WooCommerce, WooCommerce Blocks and Gutenberg
+   *    $ wp woo-test-environment setup --blocks --gutenberg
+   *
+   *    # Installing WooCommerce and WooCommerce Blocks 7.3.0
+   *    $ wp woo-test-environment setup --blocks=7.3.0
+   * 
+   *    # Installing WooCommerce and WooCommerce Blocks via URL
+   *    $ wp woo-test-environment setup --blocks=//github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
+   *
+   *    # Installing WooCommerce and Storefront
+   *    $ wp woo-test-environment setup --theme=storefront
+   *
+   *    # Installing WooCommerce, WooCommerce Blocks, Gutenberg and Storefront
+   *    $ wp woo-test-environment setup --blocks --gutenberg --theme=storefront
 	 *
 	 * @param array $args An array with optional arguments.
 	 * @param array $assoc_args An array with optional arguments.

--- a/command.php
+++ b/command.php
@@ -36,26 +36,26 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-* 		# Installing WooCommerce only
-   *    $ wp woo-test-environment setup
-   *
-   *    # Installing WooCommerce and WooCommerce Blocks
-   *    $ wp woo-test-environment setup --blocks
-   *
-   *    # Installing WooCommerce, WooCommerce Blocks and Gutenberg
-   *    $ wp woo-test-environment setup --blocks --gutenberg
-   *
-   *    # Installing WooCommerce and WooCommerce Blocks 7.3.0
-   *    $ wp woo-test-environment setup --blocks=7.3.0
-   *
-   *    # Installing WooCommerce and WooCommerce Blocks via URL
-   *    $ wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
-   *
-   *    # Installing WooCommerce and Storefront
-   *    $ wp woo-test-environment setup --theme=storefront
-   *
-   *    # Installing WooCommerce, WooCommerce Blocks, Gutenberg and Storefront
-   *    $ wp woo-test-environment setup --blocks --gutenberg --theme=storefront
+	 *    # Installing WooCommerce only
+	 *    $ wp woo-test-environment setup
+	 *
+	 *    # Installing WooCommerce and WooCommerce Blocks
+	 *    $ wp woo-test-environment setup --blocks
+	 *
+	 *    # Installing WooCommerce, WooCommerce Blocks and Gutenberg
+	 *    $ wp woo-test-environment setup --blocks --gutenberg
+	 *
+	 *    # Installing WooCommerce and WooCommerce Blocks 7.3.0
+	 *    $ wp woo-test-environment setup --blocks=7.3.0
+	 *
+	 *    # Installing WooCommerce and WooCommerce Blocks via URL
+	 *    $ wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
+	 *
+	 *    # Installing WooCommerce and Storefront
+	 *    $ wp woo-test-environment setup --theme=storefront
+	 *
+	 *    # Installing WooCommerce, WooCommerce Blocks, Gutenberg and Storefront
+	 *    $ wp woo-test-environment setup --blocks --gutenberg --theme=storefront
 	 *
 	 * @param array $args An array with optional arguments.
 	 * @param array $assoc_args An array with optional arguments.

--- a/command.php
+++ b/command.php
@@ -47,9 +47,9 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
    *
    *    # Installing WooCommerce and WooCommerce Blocks 7.3.0
    *    $ wp woo-test-environment setup --blocks=7.3.0
-   * 
+   *
    *    # Installing WooCommerce and WooCommerce Blocks via URL
-   *    $ wp woo-test-environment setup --blocks=//github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
+   *    $ wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
    *
    *    # Installing WooCommerce and Storefront
    *    $ wp woo-test-environment setup --theme=storefront

--- a/command.php
+++ b/command.php
@@ -21,7 +21,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--blocks[=<version>]]
+	 * [--blocks[=<version|url>]]
 	 * : The desired WooCommerce Blocks version to install.
 	 * Specify a version number to install a specific release. Leave empty to install the latest version.
 	 * Specify a link to the zip version to install from a remote source.

--- a/command.php
+++ b/command.php
@@ -23,8 +23,9 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * [--blocks[=<version|url>]]
 	 * : The desired WooCommerce Blocks version to install.
-	 * Specify a version number to install a specific release. Leave empty to install the latest version.
-	 * Specify a link to the zip version to install from a remote source.
+	 * --blocks: will install the latest version.
+	 * --blocks=<version>: will install the specified plugin version.
+	 * --blocks=<url>: will install the plugin from the specified URL.
 	 *
 	 * [--gutenberg]
 	 * : Whether to install and activate the Gutenberg plugin.
@@ -35,7 +36,13 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp woo-test-environment setup --blocks=true --gutenberg=true --theme=storefront
+	 *    wp woo-test-environment setup --blocks
+	 *    wp woo-test-environment setup --blocks=7.9.0
+	 *    wp woo-test-environment setup --blocks=//github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
+	 *
+	 *    wp woo-test-environment setup --gutenberg
+	 *
+	 *    wp woo-test-environment setup --theme=storefront
 	 *
 	 * @param array $args An array with optional arguments.
 	 * @param array $assoc_args An array with optional arguments.


### PR DESCRIPTION
Fixes https://github.com/nielslange/woo-test-environment/issues/4

This PR allows installing the WooCommerce Blocks plugin from a URL using the `--blocks` param.
Example: `wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip`

## Testing steps

1. Check out this repo.
2. Switch to the `add/4-install-blocks-from-link` branch.
3. Install the WP-CLI custom command using
```
wp package install <path-to-your-local-repo>
```
4. Spin up a test environment with the most recent version of WooCommerce Blocks using
```
wp woo-test-environment setup --blocks
```
5. Tear down the test environment using
```
wp woo-test-environment teardown
```
6. Spin up a test environment with WooCommerce Blocks 7.9.0 using
```
wp woo-test-environment setup --blocks=7.9.0
```
7. Tear down the test environment using
```
wp woo-test-environment teardown
```
8. Spin up a test environment with WooCommerce Blocks 7.9.0 using
```
wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
```