### PR TITLE
Try installing via artifacts URL

### DIFF
--- a/command.php
+++ b/command.php
@@ -76,18 +76,18 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 		WP_CLI::log( 'Set up WooCommerce Blocks Testing Environment ...' );
 
 		$this->setupPlugins( $assoc_args );
-		$this->setupThemes( $assoc_args );
-		$this->emptySite();
-		$this->setupProducts();
-		$this->setupPages();
-		$this->setupPosts();
-		$this->setupSidebar();
-		$this->setupShipping();
-		$this->setupPayments( $assoc_args );
-		$this->setupTax();
-		$this->setupCoupons();
-		$this->setupReviews();
-		$this->setupPermalinks();
+		// $this->setupThemes( $assoc_args );
+		// $this->emptySite();
+		// $this->setupProducts();
+		// $this->setupPages();
+		// $this->setupPosts();
+		// $this->setupSidebar();
+		// $this->setupShipping();
+		// $this->setupPayments( $assoc_args );
+		// $this->setupTax();
+		// $this->setupCoupons();
+		// $this->setupReviews();
+		// $this->setupPermalinks();
 
 		WP_CLI::success( 'WooCommerce Blocks Testing Environment successfully set up.' );
 	}
@@ -396,6 +396,33 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 
 		if ( ! $url ) {
 			return;
+		}
+
+		if ( false !== strpos( $url, 'artifacts' ) ) {
+			$auth_token = $this->getInput( 'Enter your GitHub auth token: ' );
+			if ( empty( $auth_token ) ) {
+				WP_CLI::warning( 'Empty GitHub auth token, skipping plugin installation via artifacts URL.' );
+				return;
+			}
+
+			$ch = curl_init();
+			preg_match( '/artifacts\/([1-9]+)/', $url, $matches );
+			$url = sprintf( 'https://api.github.com/repos/woocommerce/woocommerce-blocks/actions/artifacts/%d/zip', $matches[1] );
+			curl_setopt( $ch, CURLOPT_URL, $url );
+			curl_setopt( $ch, CURLOPT_HTTPHEADER, array( "Authorization: token {$auth_token}", 'User-Agent: Woo-Test-Environment' ) );
+			curl_setopt( $ch, CURLOPT_HEADER, true );
+			curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+			$response = curl_exec( $ch );
+			$error = curl_error( $ch );
+
+			if ( '' !== $error ) {
+				die( $error ); // phpcs:ignore
+			}
+
+			preg_match( '/location:\s(.*)\n/im', $response, $matches );
+
+			$url = $matches[1];
+			curl_close( $ch );
 		}
 
 		try {


### PR DESCRIPTION
In #11, @albarin added the possibility to install a WooCommerce Blocks version via a URL:

```
wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/releases/download/v7.8.2/woo-gutenberg-products-block.zip
```

While working on https://github.com/woocommerce/woocommerce-blocks/issues/6623, I managed to create a release ZIP for each PR and convert it to an artifact. This PR aims to enhance #11 to allow the a certain WooCommerce Blocks PR to be installed via the artifacts URL. An example of an artifacts URL can be found on https://github.com/woocommerce/woocommerce-blocks/actions/runs/2636447630. An example call using the artifacts URL would look like this:

```
wp woo-test-environment setup --blocks=https://github.com/woocommerce/woocommerce-blocks/suites/7275729875/artifacts/292926487
```