### PR TITLE
Make helper functions private

### DIFF
--- a/command.php
+++ b/command.php
@@ -422,7 +422,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * @return false|int
 	 */
-	public function isReleaseVersion( $version ) {
+	private function isReleaseVersion( $version ) {
 		return preg_match( '/^\d.\d.\d$/', $version );
 	}
 
@@ -433,7 +433,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 *
 	 * @return bool
 	 */
-	public function isUrl( $url ): bool {
+	private function isUrl( $url ): bool {
 		return filter_var( $url, FILTER_VALIDATE_URL );
 	}
 


### PR DESCRIPTION
While running `wp woo-test-environment`, I noticed that the commands `wp woo-test-environment isReleaseVersion` and `wp woo-test-environment isUrl` were public. This PR aims to make these functions private, as they won't be called publicly.