### PR TITLE
Regenerate product lookup table after importing

### DIFF
--- a/command.php
+++ b/command.php
@@ -179,6 +179,7 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 */
 	private function setupProducts() {
 		WP_CLI::runcommand( 'import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip' );
+		WP_CLI::runcommand( 'wc tool run regenerate_product_lookup_tables --user=1' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/nielslange/woo-test-environment/issues/17

If the lookup table is not up to date, some product properties won't be properly applied to products and product filters won't work.

1. Head to the "Active Filters" page.
2. Check that the "Filter by Price" block appears on the front-end.
3. Check that selecting "in stock" in the "Filter by Stock Status" block returns several products as results.