### PR TITLE
Create attributes before importing products

### DIFF
--- a/command.php
+++ b/command.php
@@ -178,6 +178,9 @@ class WooCommerce_Blocks_Testing_Environment extends WP_CLI_Command {
 	 * @return void
 	 */
 	private function setupProducts() {
+		WP_CLI::runcommand( 'wc product_attribute create --name=Color --slug=pa_color --user=1' );
+		WP_CLI::runcommand( 'wc product_attribute create --name=Size --slug=pa_size --user=1' );
+
 		WP_CLI::runcommand( 'import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip' );
 		WP_CLI::runcommand( 'wc tool run regenerate_product_lookup_tables --user=1' );
 	}


### PR DESCRIPTION
Fixes https://github.com/nielslange/woo-test-environment/issues/15

The importer does not create the attributes, so they are never assigned to products during the import process. We need to create them manually first.

1. On a fresh WP installation, execute: `wp woo-test-environment setup`
2. Go to `/wp-admin/edit.php?post_type=product&page=product_attributes` and check that Color and Size attributes exist.
3. Go to a product, edit it and check that it has attributes assigned.